### PR TITLE
Added FormatCheck workflow. Fixed typo in legacy FORTRAN code. Fixed typo in .gitgnore

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,33 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags: '*'
+  pull_request:
+    branches:
+      - 'main'
+    tags: '*'
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.3.0]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - uses: actions/checkout@v1
+      - name: Install JuliaFormatter and format
+        # This will use the latest version by default but you can set the version like so:
+        #
+        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
+        run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
+      

--- a/.gitignore
+++ b/.gitignore
@@ -305,4 +305,4 @@ docs/site/
 # It records a fixed state of all packages used by the project. As such, it should not be
 # committed for packages, but should be committed for applications that require a static
 # environment.
-Manifest.tomln
+Manifest.toml

--- a/Resources/fortran_src/vdisp.for
+++ b/Resources/fortran_src/vdisp.for
@@ -81,8 +81,8 @@ C	CALCULATION OF EFFECTIVE OVERBURDEN PRESSURE
       IF(NOPT.NE.0.OR.IOPTION.EQ.0)GOTO 120
       MO=IFIX(DGWT/DX) 
       IF(MO.GT.NNP)MO=NNP 
-
-      DOI=1,MO
+C     Line below previously had type (no space b/w DO I)
+      DO I=1,MO
       BN=DGWT/DX-FLOAT(I-1) 
       P(I)=P(I)+BN*DX*GAW
       ENDDO


### PR DESCRIPTION
## FormatCheck.yml
Added new workflow FormatCheck.yml
- installs package `JuliaFormatter`
- formats all files
> *Note*: might update this file to only format code in `vdisp/src` 

## FORTRAN Typo
Fixed typo in `vdisp/Resources/fortran_src/vdisp.for` on [line 85](https://github.com/smiths/vdisp/blob/0ee717473b63e17b6b0152c12a2181bdb9aff6e5/fortran_src/vdisp.for#L85).

## gitignore Typo
Fixed typo in last line of `.gitignore`. It said `Manifest.tomln` instead of `Manifest.toml`