### PR TITLE
Update comments input

### DIFF
--- a/src/InputParser.jl
+++ b/src/InputParser.jl
@@ -59,6 +59,7 @@ function parseCurrentLine(input::Array{String}, items::Int, index::Int)
     currentLine = replace(currentLine, "\t" => " ")
     currentLineData = split(currentLine, " ")
     currentLineData = filter(x -> x != "", currentLineData)
+    println(currentLineData)
     # Check if data is there
     if size(currentLineData)[1] < items
         throw(NotEnoughValuesError(Int(NotEnoughValuesErrorId), items, size(currentLineData)[1], index))
@@ -113,8 +114,18 @@ struct InputData
         end
 
         # Only allow lines that have non empty space chars
+        # input_not_empty = filter(contains(r"[^\s]"), input)
+        # Remove comments
+        input = [] # Reinitialize array of lines
+        for line in input_not_empty
+            # Split at comment
+            line_split = split(line, "#")
+            # Add all data before comment to output
+            push!(input, line_split[1])
+        end
+        # Get rid of empty lines (these lines only contained comments before)
         input = filter(contains(r"[^\s]"), input)
-        
+
         # Keep track of last line read
         lastLineIndex = 0
 
@@ -134,6 +145,7 @@ struct InputData
                 throw(ParsingError())
             end
         end
+
         # Parse each value
         numProblems = 0
         model = CollapsibleSoil
@@ -146,7 +158,7 @@ struct InputData
                 println("Error, invalid value on line $(lastLineIndex+1)!")
             elseif isa(e, BoundsError)
                 # File ran out of lines
-                println("Error, encountered end of file unexpectedly!")
+                println("1 Error, encountered end of file unexpectedly!")
             else
                 # Some other problem
                 println("Unexpected error occured while reading file at $(filePath)")

--- a/src/InputParser.jl
+++ b/src/InputParser.jl
@@ -59,7 +59,6 @@ function parseCurrentLine(input::Array{String}, items::Int, index::Int)
     currentLine = replace(currentLine, "\t" => " ")
     currentLineData = split(currentLine, " ")
     currentLineData = filter(x -> x != "", currentLineData)
-    println(currentLineData)
     # Check if data is there
     if size(currentLineData)[1] < items
         throw(NotEnoughValuesError(Int(NotEnoughValuesErrorId), items, size(currentLineData)[1], index))
@@ -114,7 +113,7 @@ struct InputData
         end
 
         # Only allow lines that have non empty space chars
-        # input_not_empty = filter(contains(r"[^\s]"), input)
+        input_not_empty = filter(contains(r"[^\s]"), input)
         # Remove comments
         input = [] # Reinitialize array of lines
         for line in input_not_empty
@@ -124,7 +123,8 @@ struct InputData
             push!(input, line_split[1])
         end
         # Get rid of empty lines (these lines only contained comments before)
-        input = filter(contains(r"[^\s]"), input)
+        input::Array{String} = filter(contains(r"[^\s]"), input)
+        # For some reason, not explicitly typing this caused errors
 
         # Keep track of last line read
         lastLineIndex = 0
@@ -158,7 +158,7 @@ struct InputData
                 println("Error, invalid value on line $(lastLineIndex+1)!")
             elseif isa(e, BoundsError)
                 # File ran out of lines
-                println("1 Error, encountered end of file unexpectedly!")
+                println("Error, encountered end of file unexpectedly!")
             else
                 # Some other problem
                 println("Unexpected error occured while reading file at $(filePath)")

--- a/test/testdata/test_input_1.dat
+++ b/test/testdata/test_input_1.dat
@@ -1,3 +1,4 @@
+# Input Data taken from p.172 of https://www.publications.usace.army.mil/Portals/76/Publications/EngineerManuals/EM_1110-1-1904.pdf    
     FOOTING IN EXPANSIVE SOIL
 1   0   1   17  7   2   0.50
 1   1

--- a/test/testdata/test_input_2.dat
+++ b/test/testdata/test_input_2.dat
@@ -1,9 +1,11 @@
+# Input Data taken from p.174 of https://www.publications.usace.army.mil/Portals/76/Publications/EngineerManuals/EM_1110-1-1904.pdf
     FOOTING IN GRANULAR SOIL - LEONARD AND FROST
+# NOTE: Leonard and Frost model will be removed from final product
 1   1   1   17  7   2   0.50
 1   1
 12  2
 16  2
-1   2.700   20.000  1.540
+1   2.700   20.000  1.540   # Material properties
 2   2.650   19.300  0.900
   8.00  0   1
   1.00  3.00    3.00    0

--- a/test/testdata/test_input_3.dat
+++ b/test/testdata/test_input_3.dat
@@ -1,3 +1,4 @@
+# Input Data taken from p.176 of https://www.publications.usace.army.mil/Portals/76/Publications/EngineerManuals/EM_1110-1-1904.pdf    
     FOOTING IN GRANULAR SOIL - SCHMERTMANN
 1   2   1   17  7   2   0.50
 1   1

--- a/test/testdata/test_input_4.dat
+++ b/test/testdata/test_input_4.dat
@@ -1,3 +1,4 @@
+# Input Data taken from p.178 of https://www.publications.usace.army.mil/Portals/76/Publications/EngineerManuals/EM_1110-1-1904.pdf    
     FOOTING IN GRANULAR SOIL - SCHMERTMANN
 1   3   1   17  7   2   0.50
 1   1


### PR DESCRIPTION
Added ability to leave comments in input files. Anything after the character `#` will be ignored by the parser. This can be useful in many ways. For example a student could leave comments about where they got the data from (textbook page, online, etc..). In my test cases of bad input files I think it would be a good idea to leave comments about exactly what is wrong with the files.