### PR TITLE
Added effective stress calculation

### DIFF
--- a/src/OutputFormat/CalculationBehaviour.jl
+++ b/src/OutputFormat/CalculationBehaviour.jl
@@ -5,6 +5,10 @@ using .InputParser
 
 export CalculationOutputBehaviour, ConsolidationSwellCalculationBehaviour, LeonardFrostCalculationBehaviour, SchmertmannCalculationBehaviour, SchmertmannElasticCalculationBehaviour, CollapsibleSoilCalculationBehaviour, writeCalculationOutput, getCalculationOutput, getCalculationValue
 
+# For now this will be hardcoded into here, later it will
+# rely on our choice of units
+GAMMA_W = 0.03125
+
 ### CalculationOutputBehaviour interface ##############
 abstract type CalculationOutputBehaviour end
 function writeCalculationOutput(calcBehaviour::CalculationOutputBehaviour, path::String)
@@ -23,96 +27,277 @@ end
 ### ConsolidationSwellCalculationBehaviour "class" ####
 struct ConsolidationSwellCalculationBehaviour <: CalculationOutputBehaviour
     nodalPoints::Int
-    ConsolidationSwellCalculationBehaviour(nodalPoints::Int) = new(nodalPoints)
+    model::String
+    dx::Float64
+    soilLayerNumber::Array{Int}
+    specificGravity::Array{Float64}
+    waterContent::Array{Float64}
+    voidRatio::Array{Float64}
+    depthGroundWaterTable::Float64
+    equilibriumMoistureProfile::Bool
 end
 function getOutput(behaviour::ConsolidationSwellCalculationBehaviour)
     # getValue does the calculations
-    t = getValue(behaviour)
-    return "Random value 1: $(t[1])\nRandom value 2: $(t[2])\nRandom value 3: $(t[3])"
+    P, PP, x = getValue(behaviour)
+    
+    out = ""
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(P[i])\n"
+    end
+    out *= "\n"
+
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(PP[i])\n"
+    end
+    out *= "\n"
+
+    out *= "Random value: $(x)\n"
+
+    return out
 end
 function getValue(behaviour::ConsolidationSwellCalculationBehaviour)
     x = behaviour.nodalPoints
+
+    # Get effective stress
+    P, PP = getEffectiveStress(behaviour)
+
     # Just return some arbitrary calcultion for now
     # I will make each model return a different value 
     # to make sure things are working
-    return (x^2 - 1, 2, 3)
+    return (P, PP, 3)
 end
 ######################################################
 
 ### LeonardFrostCalculationBehaviour "class" ####
 struct LeonardFrostCalculationBehaviour <: CalculationOutputBehaviour
     nodalPoints::Int
-    LeonardFrostCalculationBehaviour(nodalPoints::Int) = new(nodalPoints)
+    model::String
+    dx::Float64
+    soilLayerNumber::Array{Int}
+    specificGravity::Array{Float64}
+    waterContent::Array{Float64}
+    voidRatio::Array{Float64}
+    depthGroundWaterTable::Float64
+    equilibriumMoistureProfile::Bool
 end
 function getOutput(behaviour::LeonardFrostCalculationBehaviour)
     # getValue does the calculations
-    t = getValue(behaviour)
-    return "Random value 1: $(t[1])\nRandom value 2: $(t[2])\nRandom value 3: $(t[3])"
+    P, PP, x = getValue(behaviour)
+    
+    out = ""
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(P[i])\n"
+    end
+    out *= "\n"
+
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(PP[i])\n"
+    end
+    out *= "\n"
+
+    out *= "Random value: $(x)\n"
+
+    return out
 end
 function getValue(behaviour::LeonardFrostCalculationBehaviour)
-     x = behaviour.nodalPoints
+    x = behaviour.nodalPoints
+
+    # Get effective stress
+    P, PP = getEffectiveStress(behaviour)
+
     # Just return some arbitrary calcultion for now
     # I will make each model return a different value 
     # to make sure things are working
-    return (x^3 - x^2 + 1, 2.34, 3*x)
+    return (P, PP, 3*x)
 end
 ######################################################
 
 ### SchmertmannCalculationBehaviour "class" ####
 struct SchmertmannCalculationBehaviour <: CalculationOutputBehaviour
     nodalPoints::Int
-    SchmertmannCalculationBehaviour(nodalPoints::Int) = new(nodalPoints)
+    model::String
+    dx::Float64
+    soilLayerNumber::Array{Int}
+    specificGravity::Array{Float64}
+    waterContent::Array{Float64}
+    voidRatio::Array{Float64}
+    depthGroundWaterTable::Float64
+    equilibriumMoistureProfile::Bool
 end
 function getOutput(behaviour::SchmertmannCalculationBehaviour)
     # getValue does the calculations
-    t = getValue(behaviour)
-    return "Random value 1: $(t[1])\nRandom value 2: $(t[2])\nRandom value 3: $(t[3])"
+    P, PP, x = getValue(behaviour)
+    
+    out = ""
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(P[i])\n"
+    end
+    out *= "\n"
+
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(PP[i])\n"
+    end
+    out *= "\n"
+
+    out *= "Random value: $(x)\n"
+
+    return out
 end
 function getValue(behaviour::SchmertmannCalculationBehaviour)
-     x = behaviour.nodalPoints
+    x = behaviour.nodalPoints
+
+    # Get effective stress
+    P, PP = getEffectiveStress(behaviour)
+
     # Just return some arbitrary calcultion for now
     # I will make each model return a different value 
     # to make sure things are working
-    return (x^5 - 4*x^2 + 3, 2/x, 3*x-30)
+    return (P, PP, 3*x-30)
 end
 ######################################################
 
 ### CollapsibleSoilCalculationBehaviour "class" ####
 struct CollapsibleSoilCalculationBehaviour <: CalculationOutputBehaviour
     nodalPoints::Int
-    CollapsibleSoilCalculationBehaviour(nodalPoints::Int) = new(nodalPoints)
+    model::String
+    dx::Float64
+    soilLayerNumber::Array{Int}
+    specificGravity::Array{Float64}
+    waterContent::Array{Float64}
+    voidRatio::Array{Float64}
+    depthGroundWaterTable::Float64
+    equilibriumMoistureProfile::Bool
 end
 function getOutput(behaviour::CollapsibleSoilCalculationBehaviour)
     # getValue does the calculations
-    t = getValue(behaviour)
-    return "Random value 1: $(t[1])\nRandom value 2: $(t[2])\nRandom value 3: $(t[3])"
+    P, PP, x = getValue(behaviour)
+    
+    out = ""
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(P[i])\n"
+    end
+    out *= "\n"
+
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(PP[i])\n"
+    end
+    out *= "\n"
+
+    out *= "Random value: $(x)\n"
+
+    return out
 end
 function getValue(behaviour::CollapsibleSoilCalculationBehaviour)
-     x = behaviour.nodalPoints
+    x = behaviour.nodalPoints
+
+    # Get effective stress
+    P, PP = getEffectiveStress(behaviour)
+
     # Just return some arbitrary calcultion for now
     # I will make each model return a different value 
     # to make sure things are working
-    return (4*x^2 - 3*x, 2.2, 3.1415)
+    return (P, PP, 3.1415)
 end
 ######################################################
 
 ### SchmertmannElasticCalculationBehaviour "class" ####
 struct SchmertmannElasticCalculationBehaviour <: CalculationOutputBehaviour
     nodalPoints::Int
-    SchmertmannElasticCalculationBehaviour(nodalPoints::Int) = new(nodalPoints)
+    model::String
+    dx::Float64
+    soilLayerNumber::Array{Int}
+    specificGravity::Array{Float64}
+    waterContent::Array{Float64}
+    voidRatio::Array{Float64}
+    depthGroundWaterTable::Float64
+    equilibriumMoistureProfile::Bool
 end
 function getOutput(behaviour::SchmertmannElasticCalculationBehaviour)
     # getValue does the calculations
-    t = getValue(behaviour)
-    return "Random value 1: $(t[1])\nRandom value 2: $(t[2])\nRandom value 3: $(t[3])"
+    P, PP, x = getValue(behaviour)
+    
+    out = ""
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(P[i])\n"
+    end
+    out *= "\n"
+
+    for i=1:behaviour.nodalPoints
+        z = (i-1)*behaviour.dx 
+        out *= "$(z), $(PP[i])\n"
+    end
+    out *= "\n"
+
+    out *= "Random value: $(x)\n"
+
+    return out
 end
 function getValue(behaviour::SchmertmannElasticCalculationBehaviour)
-     x = behaviour.nodalPoints
+    x = behaviour.nodalPoints
+
+    # Get effective stress
+    P, PP = getEffectiveStress(behaviour)
+
     # Just return some arbitrary calcultion for now
     # I will make each model return a different value 
     # to make sure things are working
-    return (3.45*x^7 - 45*x^3 + 13.45*x, 2*x, 333*x-3)
+    return (P, PP, 333*x-3)
 end
 ######################################################
+
+# Each calculation begins with an effective stress calculation
+function getEffectiveStress(behaviour::CalculationOutputBehaviour)
+    # Initialize arrays (TODO: Think of better names)
+    P = Array{Float64}(undef,behaviour.nodalPoints)
+    PP = Array{Float64}(undef,behaviour.nodalPoints)
+    
+    # Initial values
+    P[1] = 0.0
+    PP[1] = 0.0 
+    dxx = behaviour.dx
+
+    for i = 2:behaviour.nodalPoints
+        # Get material of current soil layer
+        material = behaviour.soilLayerNumber[i-1]
+        # Get material properties
+        waterContent = behaviour.waterContent[material]/100 # WC is given as percentage, we need the decimal value
+        specificGravity = behaviour.specificGravity[material]
+        voidRatio = behaviour.voidRatio[material]
+
+        # Calculate gamma_sat (Saturated unit weight - i.e when voids are filled with water)
+        gamma_sat = specificGravity * GAMMA_W * (1 + waterContent)/(1 + voidRatio)
+
+        # If we are deeper than ground water table, subtract unit weight of water
+        gamma_sat = (dxx > behaviour.depthGroundWaterTable) ? (gamma_sat - GAMMA_W) : gamma_sat
+        
+        # Effective stress of layer i is stress of previous layer plus gamma_sat*dx
+        P[i] = P[i-1] + gamma_sat * behaviour.dx
+        PP[i] = P[i]
+
+        dxx += behaviour.dx
+    end
+
+    # Not sure why we have to do this, or theory behind it
+    if behaviour.model == "ConsolidationSwell" && behaviour.equilibriumMoistureProfile
+        # MO = DGWT/DX, but cannot be bigger than NNP
+        MO = min(Int(floor(behaviour.depthGroundWaterTable/behaviour.dx)), behaviour.nodalPoints)
+        for i=1:MO 
+            BN = behaviour.depthGroundWaterTable/behaviour.dx - float(i-1)
+            P[i] = P[i] + BN * GAMMA_W * behaviour.dx
+        end
+    end
+
+    # Return arrays P and PP
+    return (P, PP)
+end
 
 end # module

--- a/src/OutputFormat/OutputFormat.jl
+++ b/src/OutputFormat/OutputFormat.jl
@@ -218,15 +218,15 @@ end
 function getCalculationOutputBehaviour(outputData::OutputData)
     inputData = outputData.inputData
     if string(inputData.model) == string(InputParser.ConsolidationSwell)
-        return ConsolidationSwellCalculationBehaviour(inputData.nodalPoints)
+        return ConsolidationSwellCalculationBehaviour(inputData.nodalPoints, string(inputData.model), inputData.dx, inputData.soilLayerNumber, inputData.specificGravity, inputData.waterContent, inputData.voidRatio, inputData.depthGroundWaterTable, inputData.equilibriumMoistureProfile)
     elseif string(inputData.model) == string(InputParser.LeonardFrost)
-        return LeonardFrostCalculationBehaviour(inputData.nodalPoints)
+        return LeonardFrostCalculationBehaviour(inputData.nodalPoints, string(inputData.model), inputData.dx, inputData.soilLayerNumber, inputData.specificGravity, inputData.waterContent, inputData.voidRatio, inputData.depthGroundWaterTable, inputData.equilibriumMoistureProfile)
     elseif string(inputData.model) == string(InputParser.Schmertmann)
-        return SchmertmannCalculationBehaviour(inputData.nodalPoints)
+        return SchmertmannCalculationBehaviour(inputData.nodalPoints, string(inputData.model), inputData.dx, inputData.soilLayerNumber, inputData.specificGravity, inputData.waterContent, inputData.voidRatio, inputData.depthGroundWaterTable, inputData.equilibriumMoistureProfile)
     elseif string(inputData.model) == string(InputParser.CollapsibleSoil)
-        return CollapsibleSoilCalculationBehaviour(inputData.nodalPoints)
+        return CollapsibleSoilCalculationBehaviour(inputData.nodalPoints, string(inputData.model), inputData.dx, inputData.soilLayerNumber, inputData.specificGravity, inputData.waterContent, inputData.voidRatio, inputData.depthGroundWaterTable, inputData.equilibriumMoistureProfile)
     else
-        return SchmertmannElasticCalculationBehaviour(inputData.nodalPoints)
+        return SchmertmannElasticCalculationBehaviour(inputData.nodalPoints, string(inputData.model), inputData.dx, inputData.soilLayerNumber, inputData.specificGravity, inputData.waterContent, inputData.voidRatio, inputData.depthGroundWaterTable, inputData.equilibriumMoistureProfile)
     end
 end
 ####################################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,12 +10,17 @@ using .InputParser
 include("./tests.jl")
 using .Tests
 
-# Paths to test input files from runtests.jl
-INPUT_TEST_PATHS = ["../test/testdata/test_input_$x.dat" for x in 1:6]
-OUTPUT_TEST_PATHS = ["../test/testdata/test_output_$x.dat" for x in 1:4]
+TEST_FILES = 5
 
-testFunctions = [testFile1, testFile2, testFile3, testFile4]
-for i=1:4
+# Paths to test input files from runtests.jl
+INPUT_TEST_PATHS = ["../test/testdata/test_input_$x.dat" for x in 1:TEST_FILES]
+OUTPUT_TEST_PATHS = ["../test/testdata/test_output_$x.dat" for x in 1:TEST_FILES]
+
+# Paths to test input files with errors
+INPUT_ERROR_PATHS = ["../test/testdata/test_error_$x.dat" for x in 1:2]
+
+testFunctions = [testFile1, testFile2, testFile3, testFile4, testFile5]
+for i=1:TEST_FILES
     println("\nTesting input file $(i):")
     @testset "Test input file $(i)" begin
         outputData = 0
@@ -27,6 +32,7 @@ for i=1:4
         end
         testFunctions[i](inputData)
         # use outputData to output file
+        OutputFormat.writeDefaultOutput(outputData, OUTPUT_TEST_PATHS[i])
     end
 end
 
@@ -40,8 +46,8 @@ end
     #       Expected: ParsingError
     #       Thrown: Main.OutputFormat.InputParser.ParsingError
     # Thus, I copied the exact type from above to the line below
-    println("\nTesting file 5, error expected on line 6:")
-    @test_throws Main.OutputFormat.InputParser.ParsingError OutputData(INPUT_TEST_PATHS[5])
-    println("\nTesting file 6, error expected:")
-    @test_throws Main.OutputFormat.InputParser.SoilNumberError OutputData(INPUT_TEST_PATHS[6])
+    println("\nTesting error file 1, error expected on line 6:")
+    @test_throws Main.OutputFormat.InputParser.ParsingError OutputData(INPUT_ERROR_PATHS[1])
+    println("\nTesting error file 2, error expected:")
+    @test_throws Main.OutputFormat.InputParser.SoilNumberError OutputData(INPUT_ERROR_PATHS[2])
 end

--- a/test/testdata/test_error_1.dat
+++ b/test/testdata/test_error_1.dat
@@ -1,16 +1,15 @@
+# This file has an error for testing purposes
     FOOTING IN GRANULAR SOIL - SCHMERTMANN
 1   3   1   17  7   2   0.50
 1   1
 12  2
-9   1
 16  2
-1   2.700   20.000  1.540
+
+1   2.700   20.000        # Missing Void Ratio value for material 1
 2   2.650   19.300  0.900
   8.00  0   1
   1.00  3.00    3.00    0
-
 1   0.01    0.40    1.00    1.00    4.00
 2   0.05    0.40    1.00    1.00    4.00
-
 1   0.00    1.00    2.00    10.00   15.00
 2   0.00    0.80    1.50    8.00    12.00

--- a/test/testdata/test_error_2.dat
+++ b/test/testdata/test_error_2.dat
@@ -1,13 +1,17 @@
+# This file has an error for testing purposes
     FOOTING IN GRANULAR SOIL - SCHMERTMANN
 1   3   1   17  7   2   0.50
 1   1
 12  2
+9   1   # Illegal syntax for specifying soil layer numbers (9<12)
 16  2
 1   2.700   20.000  1.540
 2   2.650   19.300  0.900
   8.00  0   1
   1.00  3.00    3.00    0
+
 1   0.01    0.40    1.00    1.00    4.00
 2   0.05    0.40    1.00    1.00    4.00
+
 1   0.00    1.00    2.00    10.00   15.00
 2   0.00    0.80    1.50    8.00    12.00

--- a/test/testdata/test_input_5.dat
+++ b/test/testdata/test_input_5.dat
@@ -1,13 +1,14 @@
-    FOOTING IN GRANULAR SOIL - SCHMERTMANN
-1   3   1   17  7   2   0.50
+    FOOTING IN EXPANSIVE SOIL
+1   0   1   17  7   2   0.50
 1   1
 12  2
 16  2
-1   2.700   20.000
+1   2.700   20.000  1.540
 2   2.650   19.300  0.900
-  8.00  0   1
+# Same as input data 1 but IOPTION set to 1 on line below
+  8.00  1   1    # This is case where effective stress gets adjusted 
+# Adjustment corresponding to equations of method 2 in Figure 5-1 on p.99 of settlement analysis book
   1.00  3.00    3.00    0
-1   0.01    0.40    1.00    1.00    4.00
-2   0.05    0.40    1.00    1.00    4.00
-1   0.00    1.00    2.00    10.00   15.00
-2   0.00    0.80    1.50    8.00    12.00
+1   2.0000  0.1500  0.2500  2.000
+2   3.0000  0.1000  0.2000  3.000
+  8.00  0

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -7,7 +7,7 @@ using .OutputFormat
 include("../src/InputParser.jl")
 using .InputParser
 
-export testFile1, testFile2, testFile3, testFile4
+export testFile1, testFile2, testFile3, testFile4, testFile5
 
 function testFile1(inputData)
     @test inputData.problemName == "    FOOTING IN EXPANSIVE SOIL"
@@ -119,5 +119,33 @@ function testFile4(inputData)
     @test inputData.strainAtPoints[2,2] == 0.80
     @test inputData.strainAtPoints[2,4] == 8.00
 end
+
+function testFile5(inputData)
+    @test inputData.problemName == "    FOOTING IN EXPANSIVE SOIL"
+    @test inputData.nodalPoints == 17
+    @test inputData.bottomPointIndex == 7
+    @test inputData.soilLayers == 2
+    @test inputData.dx == 0.5
+    @test string(inputData.model) == string(InputParser.ConsolidationSwell)
+    @test string(inputData.foundation) == string(InputParser.RectangularSlab)
+    @test inputData.soilLayerNumber[1] == 1
+    @test inputData.soilLayerNumber[7] == 1
+    @test inputData.soilLayerNumber[12] == 2
+    @test inputData.soilLayerNumber[14] == 2
+    @test inputData.soilLayerNumber[16] == 2
+    @test inputData.specificGravity[1] == 2.700
+    @test inputData.voidRatio[1] == 1.540
+    @test inputData.waterContent[2] == 19.300
+    @test inputData.depthGroundWaterTable == 8.00
+    @test inputData.equilibriumMoistureProfile == true
+    @test inputData.appliedPressure == 1.00
+    @test inputData.foundationLength == 3.00
+    @test inputData.center == true
+    @test inputData.swellPressure[1] == 2.00
+    @test inputData.swellIndex[2] == 0.10
+    @test inputData.compressionIndex[1] == 0.25
+    @test inputData.heaveActiveZoneDepth == 8.00
+end
+
 
 end # module 


### PR DESCRIPTION
## Effective Stress

Module `CalculationBehaviourOutput` now has a function `getEffectiveStress`. The effective stress calculation is always done at the beginning of each model's calculations, and will only ever be needed in this module, so I leave it as a secret of this module. For now I output the calculated effective stress values in each models CalculationOutput, just to see if it is working. The original code doesn't output the effective stress values but maybe in the future we could have an option for this (the code is structured in a way that this would only require a simple `if` statement).

## Test cases

Firstly, I separated the test cases that are proper input files and the ones that have expected errors. I also added `input_test_5.dat`. This file tests the special case where some effective stress values are adjusted according to Method 2 of Figure 5-1 on p.99 of [Settlements Analysis textbook](https://www.publications.usace.army.mil/Portals/76/Publications/EngineerManuals/EM_1110-1-1904.pdf) as discussed in [this comment](https://github.com/smiths/vdisp/issues/14#issuecomment-1146170792) in issue #14. I also made each of these test input files write to their corresponding output files, so `make test` will produce 5 output files you can inspect. In the 5th output file, `test_output_5.dat`, you can see that the effective stress was adjusted as expected (the first "table" of values which represents array `P` is different to the second "table" of values which represents array `PP`).

> Note: I am not sure why the original code had two arrays, `P` and `PP`, and why only one was adjusted. I am also trying to come up with better names for these arrays.
> Note: I left one input file with no comments to implement the boundary case as discussed in a previous PR