### PR TITLE
Added precompile rule to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ LATEX_AUX_EXTENSIONS ?= aux fdb_latexmk fls log out synctex.gz toc
 
 all: run
 
+precompile:
+	julia -e "using Pkg; Pkg.activate(\".\"); Pkg.instantiate()"
+
 run:
 	julia --project=@. src/vdisp.jl "./src/.data/input_data.dat" "./src/.data/output_data.dat"
 


### PR DESCRIPTION
As seen in the [Makefile](https://github.com/EmilSoleymani/JuliaThermostat/blob/main/Makefile) of the thermostat project, the precompile rule is useful to run prior to the first time executing `make run`. We can put this in the instructions for how to install/run VDisp