### PR TITLE
Added docstring with relevant theory/formulas for getEffectiveStress function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ LATEX_AUX_EXTENSIONS ?= aux fdb_latexmk fls log out synctex.gz toc
 
 all: run
 
+buildDocs:
+	julia --project=@. docs/make.jl
+
 precompile:
 	julia -e "using Pkg; Pkg.activate(\".\"); Pkg.instantiate()"
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ buildDocs:
 	julia --project=@. docs/make.jl
 
 precompile:
+	julia -e "using Pkg; Pkg.activate(\"docs\"); Pkg.instantiate()"
 	julia -e "using Pkg; Pkg.activate(\".\"); Pkg.instantiate()"
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ buildDocs:
 	julia --project=@. docs/make.jl
 
 precompile:
+	rm -f Manifest.toml
 	julia -e "using Pkg; Pkg.activate(\"docs\"); Pkg.instantiate()"
 	julia -e "using Pkg; Pkg.activate(\".\"); Pkg.instantiate()"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,10 @@
 name = "vdisp"
 uuid = "1fd2e427-88f4-44b2-b43e-ed37557d4673"
-authors = ["emilsoleymani "]
+authors = ["Dr. Spencer Smith", "Dr. Dieter Stolle", "Emil Soleymani"]
 version = "0.1.0"
 
 [deps]
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -14,3 +14,5 @@ site/
 *.cb
 *.cb2
 .*.lb
+
+Manifest.toml

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,13 @@
 using Documenter
 using vdisp
 
+include("../src/OutputFormat/CalculationBehaviour.jl")
+using .CalculationBehaviour
+
 makedocs(
     sitename = "vdisp",
     format = Documenter.HTML(),
-    modules = [vdisp]
+    modules = [vdisp, CalculationBehaviour]
 )
 
 # Documenter can also automatically deploy documentation to gh-pages.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,6 +2,7 @@
 
 ```@docs
 vdisp.readInputFile
+CalculationBehaviour.getEffectiveStress
 ```
 
 Documentation for vdisp.jl

--- a/src/OutputFormat/CalculationBehaviour.jl
+++ b/src/OutputFormat/CalculationBehaviour.jl
@@ -3,7 +3,7 @@ module CalculationBehaviour
 include("../InputParser.jl")
 using .InputParser
 
-export CalculationOutputBehaviour, ConsolidationSwellCalculationBehaviour, LeonardFrostCalculationBehaviour, SchmertmannCalculationBehaviour, SchmertmannElasticCalculationBehaviour, CollapsibleSoilCalculationBehaviour, writeCalculationOutput, getCalculationOutput, getCalculationValue
+export CalculationOutputBehaviour, ConsolidationSwellCalculationBehaviour, LeonardFrostCalculationBehaviour, SchmertmannCalculationBehaviour, SchmertmannElasticCalculationBehaviour, CollapsibleSoilCalculationBehaviour, writeCalculationOutput, getCalculationOutput, getCalculationValue, getEffectiveStress
 
 # For now this will be hardcoded into here, later it will
 # rely on our choice of units
@@ -254,7 +254,33 @@ function getValue(behaviour::SchmertmannElasticCalculationBehaviour)
 end
 ######################################################
 
-# Each calculation begins with an effective stress calculation
+@doc raw"""
+    getEffectiveStress(behaviour)
+
+Calculates the effective stress at each nodal point given values in the
+`InputData` instance contained in `behaviour`. Returns two identical 
+Float64 arrays (unless model is ConsolidationSwell and equilibrium moisture 
+profile is saturated above water table). `VDisp` never alters the second array
+so the original effective stress values are always available for each nodal point, 
+and alters the first array adding all other stress values to each corresponding
+nodal point.
+
+# Calculations
+
+The effective stress at depth `z`, ``\sigma'_z``, is calculated using the following formulas:
+
+``\sigma'_z = (\gamma_{sat}-\gamma_w)z``
+
+Which can be derived from the following equations:
+
+``\sigma_z = \sigma'_z + u_w``
+
+``u_w = \gamma_w z``
+
+``\sigma_z = \gamma_{sat} z``
+
+This calculation is repeated at each depth increment.
+"""
 function getEffectiveStress(behaviour::CalculationOutputBehaviour)
     # Initialize arrays (TODO: Think of better names)
     P = Array{Float64}(undef,behaviour.nodalPoints)


### PR DESCRIPTION
## Documentation

After researching the `Documenter.jl` docs to learn how LaTeX and markdown syntax is interpreted  (the LaTeX part took some practice), I added a docstring for the `getEffectiveStress` function.

## Makefile

Added `make buildDocs` rule to the `Makefile` which quickly builds the `index.html` static file from the `index.md` markdown, allowing us to locally view the documentation before deploying.